### PR TITLE
feat: Specify when a timestamp is approximated and may not be accurate

### DIFF
--- a/src/Websocket.jsx
+++ b/src/Websocket.jsx
@@ -320,7 +320,7 @@ export const Websocket = ({ wsKey }) => {
         lastReceiveTime.current = now;
         setLastLineReceivedAt(now);
 
-        const { lineId, timestamp, uploadTime, segments, mediaAvailable } = data;
+        const { lineId, timestamp, uploadTime, segments, mediaAvailable, vodAccurate } = data;
 
         addMetric({
             type: "line",
@@ -336,6 +336,7 @@ export const Websocket = ({ wsKey }) => {
             timestamp: timestamp,
             segments: segments,
             mediaAvailable: mediaAvailable,
+            vodAccurate: vodAccurate
         };
 
         addTranscriptLine(newLine);

--- a/src/Websocket.jsx
+++ b/src/Websocket.jsx
@@ -336,7 +336,7 @@ export const Websocket = ({ wsKey }) => {
             timestamp: timestamp,
             segments: segments,
             mediaAvailable: mediaAvailable,
-            vodAccurate: vodAccurate
+            vodAccurate: vodAccurate,
         };
 
         addTranscriptLine(newLine);

--- a/src/components/DevToolsPopup.jsx
+++ b/src/components/DevToolsPopup.jsx
@@ -50,6 +50,7 @@ export default function DevToolsPopup() {
     const resetTranscript = useAppStore((state) => state.resetTranscript);
     const addTranscriptLine = useAppStore((state) => state.addTranscriptLine);
     const updateLineMedia = useAppStore((state) => state.updateLineMedia);
+    const updateLineVodAccurate = useAppStore((state) => state.updateLineVodAccurate);
     const recalculateClipRange = useAppStore((state) => state.recalculateClipRange);
     const setTranscript = useAppStore((state) => state.setTranscript);
     const metrics = useAppStore((state) => state.metrics);
@@ -79,6 +80,10 @@ export default function DevToolsPopup() {
     // Media Availability State
     const [mediaIds, setMediaIds] = useState("");
     const [mediaAvailable, setMediaAvailable] = useState(true);
+
+    // VOD Accuracy State
+    const [vodIds, setVodIds] = useState("");
+    const [vodAccurate, setVodAccurate] = useState(true);
 
     // Performance Metrics State
     const [fps, setFps] = useState(0);
@@ -169,6 +174,17 @@ export default function DevToolsPopup() {
             });
             updateLineMedia(selectedId, files, mediaAvailable);
             recalculateClipRange();
+        }
+    };
+
+    const handleSetVodAccurate = () => {
+        const ids = vodIds
+            .split(",")
+            .map((id) => parseInt(id.trim()))
+            .filter((id) => !isNaN(id));
+
+        if (ids.length > 0) {
+            updateLineVodAccurate(ids, vodAccurate);
         }
     };
 
@@ -438,6 +454,37 @@ export default function DevToolsPopup() {
                                     data-testid="devtools-set-media-availability"
                                     variant="contained"
                                     onClick={handleSetMediaAvailability}
+                                >
+                                    Set
+                                </Button>
+                            </Box>
+                        </Box>
+
+                        <Box sx={{ border: "1px solid #ccc", p: 2, borderRadius: 1 }}>
+                            <Typography variant="h6">VOD Accuracy</Typography>
+                            <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+                                <TextField
+                                    data-testid="devtools-vod-ids"
+                                    label="Line IDs (comma-separated)"
+                                    size="small"
+                                    value={vodIds}
+                                    onChange={(e) => setVodIds(e.target.value)}
+                                    sx={{ flexGrow: 1 }}
+                                />
+                                <FormControlLabel
+                                    data-testid="devtools-vod-accurate"
+                                    control={
+                                        <Switch
+                                            checked={vodAccurate}
+                                            onChange={(e) => setVodAccurate(e.target.checked)}
+                                        />
+                                    }
+                                    label={vodAccurate ? "Accurate" : "Approximated"}
+                                />
+                                <Button
+                                    data-testid="devtools-set-vod-accurate"
+                                    variant="contained"
+                                    onClick={handleSetVodAccurate}
                                 >
                                     Set
                                 </Button>

--- a/src/pages/transcript/Line.jsx
+++ b/src/pages/transcript/Line.jsx
@@ -39,11 +39,12 @@ const loadingAnimation = keyframes`
  * @param {Segment[]} props.segments - The segments of the line.
  * @param {boolean} [props.highlight] - Whether to highlight the line.
  * @param {boolean} [props.mediaAvailable] - Whether media is available for this line.
+ * @param {boolean} [props.vodAccurate] - Whether the line timestamp matches the VOD precisely.
  */
 const Line = memo(
     forwardRef(
         /**
-         * @param {{ id: number, lineTimestamp: number, segments: Segment[], highlight?: boolean, mediaAvailable?: boolean, startTime?: number }} props
+         * @param {{ id: number, lineTimestamp: number, segments: Segment[], highlight?: boolean, mediaAvailable?: boolean, vodAccurate?: boolean, startTime?: number }} props
          * @param {Ref} ref
          */
         ({ id, lineTimestamp, segments, highlight, tagsMap, startTime, ...props }, ref) => {
@@ -65,6 +66,7 @@ const Line = memo(
             const effectiveStartTime = startTime ?? storeStartTime;
 
             const isMediaMissing = mediaType !== "none" && props.mediaAvailable === false;
+            const isTimestampApproximated = props.vodAccurate === false;
 
             const {
                 isSelected,
@@ -242,11 +244,28 @@ const Line = memo(
                             )}
                         </IconButton>
                     </Tooltip>{" "}
-                    [
-                    <TimestampTheme theme={theme} style={{ color: timestampColor }}>
-                        {convertTime(lineTimestamp)}
-                    </TimestampTheme>
-                    ]{" "}
+                    <Tooltip
+                        title={
+                            isTimestampApproximated
+                                ? "Timestamp is approximated and may not align precisely with the VOD"
+                                : ""
+                        }
+                    >
+                        <span data-testid={isTimestampApproximated ? `line-timestamp-${id}-approx` : undefined}>
+                            [
+                            <TimestampTheme
+                                theme={theme}
+                                style={{
+                                    color: timestampColor,
+                                    opacity: isTimestampApproximated ? 0.75 : 1,
+                                }}
+                            >
+                                {isTimestampApproximated ? "≈" : ""}
+                                {convertTime(lineTimestamp)}
+                            </TimestampTheme>
+                            ]
+                        </span>
+                    </Tooltip>{" "}
                     {hasSegments ? (
                         segments.map((segment, index) => {
                             const segmentTags = tagsMap?.get(`${id}_${index}`);

--- a/src/pages/transcript/TranscriptFrame.jsx
+++ b/src/pages/transcript/TranscriptFrame.jsx
@@ -229,6 +229,7 @@ export default function TranscriptFrame({ mediaBaseUrl, displayData, streamId, w
                                     lineTimestamp={selectedLine.timestamp}
                                     segments={selectedLine.segments}
                                     mediaAvailable={selectedLine.mediaAvailable}
+                                    vodAccurate={selectedLine.vodAccurate}
                                     tagsMap={tagsMap}
                                     startTime={startTime}
                                 />

--- a/src/pages/transcript/TranscriptPagination.jsx
+++ b/src/pages/transcript/TranscriptPagination.jsx
@@ -114,6 +114,7 @@ export default function TranscriptPagination({ displayData, pendingJumpId, setPe
                             lineTimestamp={line.timestamp}
                             segments={line.segments}
                             mediaAvailable={line.mediaAvailable}
+                            vodAccurate={line.vodAccurate}
                             tagsMap={tagsMap}
                             startTime={startTime}
                         />

--- a/src/pages/transcript/TranscriptVirtual.jsx
+++ b/src/pages/transcript/TranscriptVirtual.jsx
@@ -159,6 +159,7 @@ export default function TranscriptVirtual({
                             segments={line.segments}
                             highlight={highlightedId === line.id}
                             mediaAvailable={line.mediaAvailable}
+                            vodAccurate={line.vodAccurate}
                             tagsMap={tagsMap}
                             startTime={startTime}
                         />

--- a/src/store/transcriptSlice.ts
+++ b/src/store/transcriptSlice.ts
@@ -46,9 +46,7 @@ export const createTranscriptSlice: AppSliceCreator<TranscriptSlice> = (set) => 
         set((state) => {
             const idSet = new Set(ids);
             return {
-                transcript: state.transcript.map((line) =>
-                    idSet.has(line.id) ? { ...line, vodAccurate } : line,
-                ),
+                transcript: state.transcript.map((line) => (idSet.has(line.id) ? { ...line, vodAccurate } : line)),
             };
         });
     },

--- a/src/store/transcriptSlice.ts
+++ b/src/store/transcriptSlice.ts
@@ -42,6 +42,16 @@ export const createTranscriptSlice: AppSliceCreator<TranscriptSlice> = (set) => 
             }),
         }));
     },
+    updateLineVodAccurate: (ids, vodAccurate) => {
+        set((state) => {
+            const idSet = new Set(ids);
+            return {
+                transcript: state.transcript.map((line) =>
+                    idSet.has(line.id) ? { ...line, vodAccurate } : line,
+                ),
+            };
+        });
+    },
     resetTranscript: () =>
         set({
             streamId: "",

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -12,6 +12,7 @@ export interface TranscriptLine {
     segments: Segment[];
     timestamp: number;
     mediaAvailable?: boolean;
+    vodAccurate?: boolean;
 }
 
 export interface StreamInfo {
@@ -100,6 +101,7 @@ export interface TranscriptSlice {
     setTranscript: (data: TranscriptLine[]) => void;
     addTranscriptLine: (newLine: TranscriptLine) => void;
     updateLineMedia: (streamId: string, files: Files, available?: boolean) => void;
+    updateLineVodAccurate: (ids: number[], vodAccurate: boolean) => void;
     resetTranscript: () => void;
 }
 


### PR DESCRIPTION
Added `vodAccurate` data type to line. The timestamp will now indicate that it is approximated and is not perfectly accurate.

<img width="313" height="83" alt="image" src="https://github.com/user-attachments/assets/cd12795c-f9d0-430f-b5a4-f2a0e8bd469b" />

This only shows when the value is strictly false.